### PR TITLE
Use a timestamp with nanoseconds

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -27,7 +27,7 @@ import (
 	"time"
 )
 
-const timeFormat = "02 Jan 06 15:04:05 MST"
+const timeFormat = time.StampNano
 
 type Generator struct {
 	dest   io.Writer


### PR DESCRIPTION
NOTE: closed the previous PR in favor of this one

For multi-file benchmarks, many log agents use some sort of logic to
determine if a file is a duplicate or is rotated. With second-resolution
timestamps, the beginnings of files are usually identical, so the files
are often marked as duplicates by the log agent and skipped, making the
benchmarks inaccurate.

This commit changes the timestamp to one which includes nanoseconds to
mitigate that issue.

*Issue #, if available:*

*Description of changes:*

Use a timestamp with nanosecond precision.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
